### PR TITLE
Removed the need to specify the current Controller when redirecting to another.

### DIFF
--- a/System.Web.Mvc.Expressions/ControllerExtensions.cs
+++ b/System.Web.Mvc.Expressions/ControllerExtensions.cs
@@ -25,6 +25,14 @@
             return GetRedirectFromExpression(action, routeValues);
         }
 
+        public static RedirectToRouteResult RedirectToAction<TRedirectController>(
+            this Controller controller,
+            Expression<Action<TRedirectController>> action,
+            object routeValues = null) where TRedirectController : Controller
+        {
+            return GetRedirectFromExpression(action, routeValues);
+        }
+
         public static RedirectToRouteResult RedirectToActionPermanent<TController>(
             this TController controller,
             Expression<Action<TController>> action,
@@ -38,6 +46,15 @@
                 Expression<Action<TRedirectController>> action,
                 object routeValues = null)
             where TController : Controller
+            where TRedirectController : Controller
+        {
+            return GetRedirectFromExpression(action, routeValues, true);
+        }
+
+        public static RedirectToRouteResult RedirectToActionPermanent<TRedirectController>(
+                this Controller controller,
+                Expression<Action<TRedirectController>> action,
+                object routeValues = null)
             where TRedirectController : Controller
         {
             return GetRedirectFromExpression(action, routeValues, true);


### PR DESCRIPTION
Example:

If you are in AccountController and you need to redirect to the Index action of the ManageController you needed to call the method this way :

this.RedirectToAction< AccountController, ManageController>(c => c.Index());

Now you can call it this way :
this.RedirectToAction< ManageController>(c => c.Index());

Works the same way for RedirectToActionPermanent .

I did not remove the old methods in order to preserve backward compatibility.